### PR TITLE
added support for optional clusterName via config file

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,16 +3,17 @@ package main
 import (
 	"context"
 	"flag"
-	"github.com/opsgenie/kubernetes-event-exporter/pkg/exporter"
-	"github.com/opsgenie/kubernetes-event-exporter/pkg/kube"
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	"github.com/opsgenie/kubernetes-event-exporter/pkg/exporter"
+	"github.com/opsgenie/kubernetes-event-exporter/pkg/kube"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -67,7 +68,16 @@ func main() {
 	}
 
 	engine := exporter.NewEngine(&cfg, &exporter.ChannelBasedReceiverRegistry{})
-	w := kube.NewEventWatcher(kubeconfig, cfg.Namespace, cfg.ThrottlePeriod, engine.OnEvent)
+	onEvent := engine.OnEvent
+	if len(cfg.ClusterName) != 0 {
+		onEvent = func(event *kube.EnhancedEvent) {
+			// note that per code this value is not set anywhere on the kubernetes side
+			// https://github.com/kubernetes/apimachinery/blob/v0.22.4/pkg/apis/meta/v1/types.go#L276
+			event.ClusterName = cfg.ClusterName
+			engine.OnEvent(event)
+		}
+	}
+	w := kube.NewEventWatcher(kubeconfig, cfg.Namespace, cfg.ThrottlePeriod, onEvent)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	leaderLost := make(chan bool)

--- a/pkg/exporter/config.go
+++ b/pkg/exporter/config.go
@@ -12,7 +12,8 @@ type Config struct {
 	// TODO: I am not sure what to do here.
 	LogLevel       string                    `yaml:"logLevel"`
 	LogFormat      string                    `yaml:"logFormat"`
-	ThrottlePeriod int64					 `yaml:"throttlePeriod"`
+	ThrottlePeriod int64                     `yaml:"throttlePeriod"`
+	ClusterName    string                    `yaml:"clusterName,omitempty"`
 	Namespace      string                    `yaml:"namespace"`
 	LeaderElection kube.LeaderElectionConfig `yaml:"leaderElection"`
 	Route          Route                     `yaml:"route"`

--- a/pkg/kube/watcher.go
+++ b/pkg/kube/watcher.go
@@ -60,6 +60,7 @@ func (e *EventWatcher) onEvent(event *corev1.Event) {
 
 	log.Debug().
 		Str("msg", event.Message).
+		Str("clustername", event.ClusterName).
 		Str("namespace", event.Namespace).
 		Str("reason", event.Reason).
 		Str("involvedObject", event.InvolvedObject.Name).


### PR DESCRIPTION
When there are multiple clusters in an area it's essential to have the event's clustername associated with each event. The event object exposed by Kubernetes provides a clustername, but it does not set it. This PR sets the clustername.

#2