### PR TITLE
added capability to use elasticsearch datastreams

### DIFF
--- a/pkg/kube/event.go
+++ b/pkg/kube/event.go
@@ -2,14 +2,16 @@ package kube
 
 import (
 	"encoding/json"
-	corev1 "k8s.io/api/core/v1"
 	"strings"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 type EnhancedEvent struct {
 	corev1.Event   `json:",inline"`
 	InvolvedObject EnhancedObjectReference `json:"involvedObject"`
+	Timestamp      time.Time               `json:"@timestamp"`
 }
 
 // DeDot replaces all dots in the labels and annotations with underscores. This is required for example in the
@@ -45,6 +47,7 @@ type EnhancedObjectReference struct {
 // ToJSON does not return an error because we are %99 confident it is JSON serializable.
 // TODO(makin) Is it a bad practice? It's open to discussion.
 func (e *EnhancedEvent) ToJSON() []byte {
+	e.Timestamp = e.FirstTimestamp.Time
 	b, _ := json.Marshal(e)
 	return b
 }


### PR DESCRIPTION
This should fix https://github.com/resmoio/kubernetes-event-exporter/issues/17, however i am aware that the solution is nowhere near good.

However since i wasted roughly 6 hours on this small issue and how to resolve it (thanks to the great way bitnami builds their images and how this software is built - which doesnt seem to work since after the vendor update anymore via th dockerfile).

Consider this as "where to add the missing field" data wise and not as "should be merged" code.

**Please take note that this is a copy if this PR https://github.com/opsgenie/kubernetes-event-exporter/pull/165**
**Also i did not test it with this repositories most recent version of the software**