### PR TITLE
Use custom ClusterRole with wider read permissions to account for CRs

### DIFF
--- a/deploy/00-roles.yaml
+++ b/deploy/00-roles.yaml
@@ -16,8 +16,17 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: view
+  name: event-exporter
 subjects:
   - kind: ServiceAccount
     namespace: monitoring
     name: event-exporter
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: event-exporter
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["get", "watch", "list"]


### PR DESCRIPTION
This PR will fix issues like https://github.com/resmoio/kubernetes-event-exporter/issues/14, while still keeping a pod on a read-only role and without the need to list individual CRs.

---

Yamls to reproduce:  

<details>
  <summary>Apply CRD and CR</summary>

   ```
    ---
    apiVersion: apiextensions.k8s.io/v1
    kind: CustomResourceDefinition
    metadata:
      name: tests.svb.com
    spec:
      group: svb.com
      versions:
        - name: v1
          served: true
          storage: true
          schema:
            openAPIV3Schema:
              type: object
              properties:
                spec:
                  type: object
                  properties:
                    test:
                      type: string
      scope: Namespaced
      names:
        plural: tests
        singular: test
        kind: Test
        shortNames:
        - test
    ---
    apiVersion: svb.com/v1
    kind: Test
    metadata:
      name: my-new-test
      namespace: monitoring
    spec:
      test: test
   ```
</details>

<details>
  <summary>Create Event</summary>

  ```
  apiVersion: v1
  kind: Event
  metadata:
    name: event-7
    namespace: monitoring
  type: Warning
  lastTimestamp: "2022-11-26T01:31:05Z"
  message: 'test'
  involvedObject:
    apiVersion: svb.com/v1
    kind: Test
    name: my-new-test
    namespace: monitoring
    resourceVersion: "1317"
    uid: 450d992e-f652-4249-9a59-efdd86c9503a
  ```

</details>

<details>
  <summary>Forbidden with standard view role</summary>

```
# {"level":"error","error":"tests.svb.com \"my-new-test\" is forbidden: User \"system:serviceaccount:monitoring:event-exporter\" cannot get resource \"tests\" in API group \"svb.com\" in the namespace \"monitoring\"","time":"2022-11-26T01:22:59Z","caller":"/app/pkg/kube/watcher.go:121","message":"Cannot list labels of the object"}
# {"level":"error","error":"tests.svb.com \"my-new-test\" is forbidden: User \"system:serviceaccount:monitoring:event-exporter\" cannot get resource \"tests\" in API group \"svb.com\" in the namespace \"monitoring\"","time":"2022-11-26T01:22:59Z","caller":"/app/pkg/kube/watcher.go:134","message":"Cannot list annotations of the object"}
```

</details>

<details>
  <summary>Allowed with custom role</summary>

```
# {"metadata":{"name":"event-7","namespace":"monitoring","uid":"b6e99f2d-15a5-4541-bb58-769d02877cde","resourceVersion":"4489","creationTimestamp":"2022-11-26T01:31:25Z","annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"v1\",\"involvedObject\":{\"apiVersion\":\"svb.com/v1\",\"kind\":\"Test\",\"name\":\"my-new-test\",\"namespace\":\"monitoring\",\"resourceVersion\":\"1317\",\"uid\":\"450d992e-f652-4249-9a59-efdd86c9503a\"},\"kind\":\"Event\",\"lastTimestamp\":\"2022-11-26T01:31:05Z\",\"message\":\"test\",\"metadata\":{\"annotations\":{},\"name\":\"event-7\",\"namespace\":\"monitoring\"},\"type\":\"Warning\"}\n"}},"message":"test","source":{},"firstTimestamp":null,"lastTimestamp":"2022-11-26T01:31:05Z","type":"Warning","eventTime":null,"reportingComponent":"","reportingInstance":"","involvedObject":{"kind":"Test","namespace":"monitoring","name":"my-new-test","uid":"450d992e-f652-4249-9a59-efdd86c9503a","apiVersion":"svb.com/v1","resourceVersion":"1317"}}
```

</details>