### PR TITLE
fix: allow specify root ca without client/key

### DIFF
--- a/pkg/sinks/sink.go
+++ b/pkg/sinks/sink.go
@@ -35,24 +35,22 @@ type TLS struct {
 }
 
 func setupTLS(cfg *TLS) (*tls.Config, error) {
-	var caCert []byte
+	tlsClientConfig := &tls.Config{
+		InsecureSkipVerify: cfg.InsecureSkipVerify,
+		ServerName:         cfg.ServerName,
+	}
 
 	if len(cfg.CaFile) > 0 {
 		readFile, err := ioutil.ReadFile(cfg.CaFile)
 		if err != nil {
 			return nil, err
 		}
-		caCert = readFile
-	}
 
-	tlsClientConfig := &tls.Config{
-		InsecureSkipVerify: cfg.InsecureSkipVerify,
-		ServerName:         cfg.ServerName,
-	}
-	if len(cfg.KeyFile) > 0 && len(cfg.CertFile) > 0 {
 		tlsClientConfig.RootCAs = x509.NewCertPool()
-		tlsClientConfig.RootCAs.AppendCertsFromPEM(caCert)
+		tlsClientConfig.RootCAs.AppendCertsFromPEM(readFile)
+	}
 
+	if len(cfg.KeyFile) > 0 && len(cfg.CertFile) > 0 {
 		cert, err := tls.LoadX509KeyPair(cfg.CertFile, cfg.KeyFile)
 		if err != nil {
 			return nil, fmt.Errorf("could not read client certificate or key: %w", err)


### PR DESCRIPTION
Having an elasticsearch uri with https configured as well as a tls ca will end in:
```
{"level":"debug","error":"x509: certificate signed by unknown authority","sink":"dump","event":"Reconciliation finished in 205.898336ms, next run in 10m0s","time":"2022-12-02T14:34:18Z","caller":"/app/pkg/exporter/channel_registry.go:69","message":"Cannot send event"}
```

What happens currently is actually that caFile is completely ignored as long as no client/key is set as well.

config:
```yaml
    leaderElection: {}
    logFormat: json
    logLevel: debug
    receivers:
    - elasticsearch:
        deDot: true
        hosts:
        - https://logging-es-http.logging:9200
        index: k8sevents-*
        indexFormat: k8sevents-{2006-02-01}
        tls:
          caFile: /es-certs/ca.crt
      name: dump
    route:
      routes:
      - match:
        - receiver: dump

```

Signed-off-by: Raffael Sahli <raffael.sahli@doodle.com>