### PR TITLE
support MinCount via config.yaml

### DIFF
--- a/pkg/exporter/rule.go
+++ b/pkg/exporter/rule.go
@@ -23,7 +23,7 @@ type Rule struct {
 	Namespace   string
 	Reason      string
 	Type        string
-	MinCount    int32
+	MinCount    int32 `yaml:"minCount"`
 	Component   string
 	Host        string
 	Receiver    string


### PR DESCRIPTION
I want to use minCount setting. 
But, I failed to set MinCount value via config.yaml.
so, I add yaml tag to rule struct.

```yaml
route:
  routes:
    - drop:
        - minCount: 6
      match:
        - receiver: stdout
receivers:
  - name: stdout
    stdout: {}
```