### PR TITLE
Support escaping $ chars in configuration with $$

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func main() {
 		log.Fatal().Err(err).Msg("cannot read config file")
 	}
 
-	b = []byte(os.ExpandEnv(string(b)))
+	b = expandConfiguration(b)
 
 	var cfg exporter.Config
 	err = yaml.Unmarshal(b, &cfg)
@@ -143,4 +143,13 @@ func main() {
 		log.Warn().Msg("Leader election lost")
 		gracefulExit()
 	}
+}
+
+func expandConfiguration(cfg []byte) []byte {
+	return []byte(os.Expand(string(cfg), func(key string) string {
+		if key == "$" {
+			return "$"
+		}
+		return os.Getenv(key)
+	}))
 }


### PR DESCRIPTION
This PR makes it possible (and explicit) to escape/preserve `$` characters in configuration by duplicating them: `$$`.

### Motivation
I needed to configure the _Webhook_ sink to push events to Loki. The layout expected by Loki includes a nanosecond precision timestamp which I wanted to produce by the following template:
```
{{- $timestamp := .EventTime.Time }}
{{- if $timestamp.IsZero }}
  {{- $timestamp = .LastTimestamp.Time }}
  {{- if $timestamp.IsZero }}
    {{- $timestamp = now }}
  {{- end }}
{{- end }}
{{- $timestamp.UnixNano }}
```
Unfortunately no output was ever generated by this template.
After some debugging it turned out that this was not the template the go templating engine was tasked to expand - that looked something like this:
```
{{-  := .EventTime.Time }}
{{- if .IsZero }}
  {{-  = .LastTimestamp.Time }}
  {{- if .IsZero }}
    {{-  = now }}
  {{- end }}
{{- end }}
{{- .UnixNano }}
```
the reason being that the entire configuration had been expanded by the go's `os.ExpandEnv()` [here](https://github.com/resmoio/kubernetes-event-exporter/blob/858089f2dc42243c0939a7f13a76fdd22e70be0f/main.go#L36), which effectively deleted all the `$template` expressions. Unfortunately the function does not provide any means of escaping those `$` characters which are not supposed to be expanded.
Needless to say that this crippled template failed to parse so generating any output was out of question.

### Fix
To make this kind of templates possible, this PR ensures that the expansion of the configuration expands every `$$` to `$`, i.e. it makes it possible to escape the `$` characters by duplicating them.
With this fix in place, one can make the above mentioned template work by re-writing it like this:
```
{{- $$timestamp := .EventTime.Time }}
{{- if $$timestamp.IsZero }}
  {{- $$timestamp = .LastTimestamp.Time }}
  {{- if $$timestamp.IsZero }}
    {{- $$timestamp = now }}
  {{- end }}
{{- end }}
{{- $$timestamp.UnixNano }}
```

### Notes
It is possible to achieve the same result even without this PR, by:
1. duplicating the `$` characters just as above
2. starting the event exporter in an environment in which there exists environment variable `$` with the value of `$`, for example like this:
   ```
   env $=$ kubernetes-event-exporter ...
   ```
The PR just makes this an explicit feature.