### PR TITLE
Consolidate metrics code in a single package, add metrics prefix config option

### DIFF
--- a/deploy/01-config.yaml
+++ b/deploy/01-config.yaml
@@ -5,8 +5,9 @@ metadata:
   namespace: monitoring
 data:
   config.yaml: |
-    logLevel: error
+    logLevel: warn
     logFormat: json
+    metricsNamePrefix: event_exporter_
     route:
       routes:
         - match:

--- a/pkg/exporter/engine.go
+++ b/pkg/exporter/engine.go
@@ -1,9 +1,10 @@
 package exporter
 
 import (
+	"reflect"
+
 	"github.com/resmoio/kubernetes-event-exporter/pkg/kube"
 	"github.com/rs/zerolog/log"
-	"reflect"
 )
 
 // Engine is responsible for initializing the receivers from sinks

--- a/pkg/kube/watcher_test.go
+++ b/pkg/kube/watcher_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/resmoio/kubernetes-event-exporter/pkg/metrics"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -14,13 +16,14 @@ import (
 func TestEventWatcher_EventAge_whenEventCreatedBeforeStartup(t *testing.T) {
 	// should not discard events as old as 300s=5m
 	var MaxEventAgeSeconds int64 = 300
-	ew := NewMockEventWatcher(MaxEventAgeSeconds)
+	metricsStore := metrics.NewMetricsStore("test_")
+	ew := NewMockEventWatcher(MaxEventAgeSeconds, metricsStore)
 	output := &bytes.Buffer{}
 	log.Logger = log.Logger.Output(output)
 
 	// event is 3m before stratup time -> expect silently dropped
 	startup := time.Now().Add(-10 * time.Minute)
-	ew.SetStartUpTime(startup)
+	ew.setStartUpTime(startup)
 	event1 := corev1.Event{
 		LastTimestamp: metav1.Time{Time: startup.Add(-3 * time.Minute)},
 	}
@@ -30,6 +33,7 @@ func TestEventWatcher_EventAge_whenEventCreatedBeforeStartup(t *testing.T) {
 	assert.NotContains(t, output.String(), "Event discarded as being older then maxEventAgeSeconds")
 	ew.onEvent(&event1)
 	assert.NotContains(t, output.String(), "Received event")
+	assert.Equal(t, float64(0), testutil.ToFloat64(metricsStore.EventsProcessed))
 
 	event2 := corev1.Event{
 		EventTime: metav1.MicroTime{Time: startup.Add(-3 * time.Minute)},
@@ -39,6 +43,7 @@ func TestEventWatcher_EventAge_whenEventCreatedBeforeStartup(t *testing.T) {
 	assert.NotContains(t, output.String(), "Event discarded as being older then maxEventAgeSeconds")
 	ew.onEvent(&event2)
 	assert.NotContains(t, output.String(), "Received event")
+	assert.Equal(t, float64(0), testutil.ToFloat64(metricsStore.EventsProcessed))
 
 	// event is 3m before stratup time -> expect silently dropped
 	event3 := corev1.Event{
@@ -50,17 +55,21 @@ func TestEventWatcher_EventAge_whenEventCreatedBeforeStartup(t *testing.T) {
 	assert.NotContains(t, output.String(), "Event discarded as being older then maxEventAgeSeconds")
 	ew.onEvent(&event3)
 	assert.NotContains(t, output.String(), "Received event")
+	assert.Equal(t, float64(0), testutil.ToFloat64(metricsStore.EventsProcessed))
+
+	metrics.DestroyMetricsStore(metricsStore)
 }
 
 func TestEventWatcher_EventAge_whenEventCreatedAfterStartupAndBeforeMaxAge(t *testing.T) {
 	// should not discard events as old as 300s=5m
 	var MaxEventAgeSeconds int64 = 300
-	ew := NewMockEventWatcher(MaxEventAgeSeconds)
+	metricsStore := metrics.NewMetricsStore("test_")
+	ew := NewMockEventWatcher(MaxEventAgeSeconds, metricsStore)
 	output := &bytes.Buffer{}
 	log.Logger = log.Logger.Output(output)
 
 	startup := time.Now().Add(-10 * time.Minute)
-	ew.SetStartUpTime(startup)
+	ew.setStartUpTime(startup)
 	// event is 8m after stratup time (2m in max age) -> expect processed
 	event1 := corev1.Event{
 		InvolvedObject: corev1.ObjectReference{
@@ -75,6 +84,7 @@ func TestEventWatcher_EventAge_whenEventCreatedAfterStartupAndBeforeMaxAge(t *te
 	ew.onEvent(&event1)
 	assert.Contains(t, output.String(), "test-1")
 	assert.Contains(t, output.String(), "Received event")
+	assert.Equal(t, float64(1), testutil.ToFloat64(metricsStore.EventsProcessed))
 
 	// event is 8m after stratup time (2m in max age) -> expect processed
 	event2 := corev1.Event{
@@ -90,6 +100,7 @@ func TestEventWatcher_EventAge_whenEventCreatedAfterStartupAndBeforeMaxAge(t *te
 	ew.onEvent(&event2)
 	assert.Contains(t, output.String(), "test-2")
 	assert.Contains(t, output.String(), "Received event")
+	assert.Equal(t, float64(2), testutil.ToFloat64(metricsStore.EventsProcessed))
 
 	// event is 8m after stratup time (2m in max age) -> expect processed
 	event3 := corev1.Event{
@@ -106,18 +117,22 @@ func TestEventWatcher_EventAge_whenEventCreatedAfterStartupAndBeforeMaxAge(t *te
 	ew.onEvent(&event3)
 	assert.Contains(t, output.String(), "test-3")
 	assert.Contains(t, output.String(), "Received event")
+	assert.Equal(t, float64(3), testutil.ToFloat64(metricsStore.EventsProcessed))
+
+	metrics.DestroyMetricsStore(metricsStore)
 }
 
 func TestEventWatcher_EventAge_whenEventCreatedAfterStartupAndAfterMaxAge(t *testing.T) {
 	// should not discard events as old as 300s=5m
 	var MaxEventAgeSeconds int64 = 300
-	ew := NewMockEventWatcher(MaxEventAgeSeconds)
+	metricsStore := metrics.NewMetricsStore("test_")
+	ew := NewMockEventWatcher(MaxEventAgeSeconds, metricsStore)
 	output := &bytes.Buffer{}
 	log.Logger = log.Logger.Output(output)
 
 	// event is 3m after stratup time (and 2m after max age) -> expect dropped with warn
 	startup := time.Now().Add(-10 * time.Minute)
-	ew.SetStartUpTime(startup)
+	ew.setStartUpTime(startup)
 	event1 := corev1.Event{
 		ObjectMeta:    metav1.ObjectMeta{Name: "event1"},
 		LastTimestamp: metav1.Time{Time: startup.Add(3 * time.Minute)},
@@ -127,6 +142,7 @@ func TestEventWatcher_EventAge_whenEventCreatedAfterStartupAndAfterMaxAge(t *tes
 	assert.Contains(t, output.String(), "Event discarded as being older then maxEventAgeSeconds")
 	ew.onEvent(&event1)
 	assert.NotContains(t, output.String(), "Received event")
+	assert.Equal(t, float64(0), testutil.ToFloat64(metricsStore.EventsProcessed))
 
 	// event is 3m after stratup time (and 2m after max age) -> expect dropped with warn
 	event2 := corev1.Event{
@@ -139,6 +155,7 @@ func TestEventWatcher_EventAge_whenEventCreatedAfterStartupAndAfterMaxAge(t *tes
 	assert.Contains(t, output.String(), "Event discarded as being older then maxEventAgeSeconds")
 	ew.onEvent(&event2)
 	assert.NotContains(t, output.String(), "Received event")
+	assert.Equal(t, float64(0), testutil.ToFloat64(metricsStore.EventsProcessed))
 
 	// event is 3m after stratup time (and 2m after max age) -> expect dropped with warn
 	event3 := corev1.Event{
@@ -152,4 +169,7 @@ func TestEventWatcher_EventAge_whenEventCreatedAfterStartupAndAfterMaxAge(t *tes
 	assert.Contains(t, output.String(), "Event discarded as being older then maxEventAgeSeconds")
 	ew.onEvent(&event3)
 	assert.NotContains(t, output.String(), "Received event")
+	assert.Equal(t, float64(0), testutil.ToFloat64(metricsStore.EventsProcessed))
+
+	metrics.DestroyMetricsStore(metricsStore)
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,65 @@
+package metrics
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+
+type Store struct {
+	EventsProcessed prometheus.Counter
+	EventsDiscarded prometheus.Counter
+	WatchErrors     prometheus.Counter
+	SendErrors	    prometheus.Counter
+}
+
+func Init(addr string) {
+	// Setup the prometheus metrics machinery
+	// Add Go module build info.
+	prometheus.MustRegister(collectors.NewBuildInfoCollector())
+
+	// Expose the registered metrics via HTTP.
+	http.Handle("/metrics", promhttp.HandlerFor(
+		prometheus.DefaultGatherer,
+		promhttp.HandlerOpts{
+			// Opt into OpenMetrics to support exemplars.
+			EnableOpenMetrics: true,
+		},
+	))
+
+	// start up the http listener to expose the metrics
+	go http.ListenAndServe(addr, nil)
+}
+
+func NewMetricsStore(name_prefix string) *Store {
+	return &Store{
+		EventsProcessed: promauto.NewCounter(prometheus.CounterOpts{
+			Name: name_prefix + "events_sent",
+			Help: "The total number of events processed",
+		}),
+		EventsDiscarded: promauto.NewCounter(prometheus.CounterOpts{
+			Name: name_prefix  + "events_discarded",
+			Help: "The total number of events discarded because of being older than the maxEventAgeSeconds specified",
+		}),
+		WatchErrors: promauto.NewCounter(prometheus.CounterOpts{
+			Name: name_prefix + "watch_errors",
+			Help: "The total number of errors received from the informer",
+		}),
+		SendErrors: promauto.NewCounter(prometheus.CounterOpts{
+			Name: name_prefix + "send_event_errors",
+			Help: "The total number of send event errors",
+		}),
+	}
+}
+
+func DestroyMetricsStore(store *Store) {
+	prometheus.Unregister(store.EventsProcessed)
+	prometheus.Unregister(store.EventsDiscarded)
+	prometheus.Unregister(store.WatchErrors)
+	prometheus.Unregister(store.SendErrors)
+	store = nil
+}


### PR DESCRIPTION
Currently, the Prometheus metrics code is slightly all over the place, which is making it difficult to figure out the code and available metrics.

This PR:
1. proposes to extract all the metrics code into a separate `metrics` package [pkg/metrics/metrics.go](https://github.com/resmoio/kubernetes-event-exporter/compare/master...Evedel:kubernetes-event-exporter:consolidate-metrics-in-single-package?expand=1#diff-4bc91a74bc47b8467cdcd25a7e3fe1651dbe44907f478377eca31b982f444f23)
    - no more prom imports and variables all over different packages
    - the metrics package is then dependency injected via input parameter, enabling [testing of metrics](https://github.com/resmoio/kubernetes-event-exporter/compare/master...Evedel:kubernetes-event-exporter:consolidate-metrics-in-single-package?expand=1#diff-39a348ac62c589ef62bfedb1b321de0a489921150f628c3eed2fee7aadc331d4)
2.  `metricsNamePrefix` is added as an optional parameter
    - if empty => all the old metric names are used, so fully backward compatible, but will warn user to set a prefix manually
      ```
      k logs event-exporter-678958f5dc-c2wwd
      {"level":"warn","caller":"/app/pkg/exporter/config.go:86","message":"metrics name prefix is empty, setting config.metricsNamePrefix='event_exporter_' is recommended"}
      ```
    - if set => all the metrics will be prefixed, easy to discover available
      ![image](https://user-images.githubusercontent.com/16960194/215765941-f7c07642-af8b-4972-83ff-180344d6c630.png)
    - [config validation is tested](https://github.com/resmoio/kubernetes-event-exporter/compare/master...Evedel:kubernetes-event-exporter:consolidate-metrics-in-single-package?expand=1#diff-87c713776281b98b07a61d980d9ee0c9d877167c25207f14cd9d55c4295d3d7b)