### PR TITLE
Use appVersion for docker image in helm chart

### DIFF
--- a/charts/kubernetes-event-exporter/Chart.yaml
+++ b/charts/kubernetes-event-exporter/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kubernetes-event-exporter/Chart.yaml
+++ b/charts/kubernetes-event-exporter/Chart.yaml
@@ -12,5 +12,5 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "1.1"
 home: https://github.com/resmoio/kubernetes-event-exporter

--- a/charts/kubernetes-event-exporter/templates/configmap.yaml
+++ b/charts/kubernetes-event-exporter/templates/configmap.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: {{ include "kubernetes-event-exporter.fullname" . }}-cfg
   namespace: {{ template "kubernetes-event-exporter.namespace" . }}
+  labels:
+    {{- include "kubernetes-event-exporter.labels" . | nindent 4 }}
 data:
   config.yaml: |
 {{ .Values.config | indent 4 }}

--- a/charts/kubernetes-event-exporter/templates/deployment.yaml
+++ b/charts/kubernetes-event-exporter/templates/deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: {{ include "kubernetes-event-exporter.fullname" . }}
   namespace: {{ include "kubernetes-event-exporter.namespace" . }}
+  labels:
+    {{- include "kubernetes-event-exporter.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/kubernetes-event-exporter/templates/deployment.yaml
+++ b/charts/kubernetes-event-exporter/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: metrics

--- a/charts/kubernetes-event-exporter/templates/role.yaml
+++ b/charts/kubernetes-event-exporter/templates/role.yaml
@@ -4,6 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "kubernetes-event-exporter.fullname" . }}
+  labels:
+    {{- include "kubernetes-event-exporter.labels" . | nindent 4 }}
 rules:
   - apiGroups: ["*"]
     resources: ["*"]

--- a/charts/kubernetes-event-exporter/templates/rolebinding.yaml
+++ b/charts/kubernetes-event-exporter/templates/rolebinding.yaml
@@ -3,7 +3,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-    name: {{ include "kubernetes-event-exporter.fullname" . }}
+  name: {{ include "kubernetes-event-exporter.fullname" . }}
+  labels:
+    {{- include "kubernetes-event-exporter.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/kubernetes-event-exporter/templates/serviceaccount.yaml
+++ b/charts/kubernetes-event-exporter/templates/serviceaccount.yaml
@@ -4,4 +4,6 @@ kind: ServiceAccount
 metadata:
   name: {{ include "kubernetes-event-exporter.serviceAccountName" . }}
   namespace: {{ include "kubernetes-event-exporter.namespace" . }}
+  labels:
+    {{- include "kubernetes-event-exporter.labels" . | nindent 4 }}
 {{- end }}

--- a/charts/kubernetes-event-exporter/values.yaml
+++ b/charts/kubernetes-event-exporter/values.yaml
@@ -7,8 +7,6 @@ replicaCount: 1
 image:
   repository: ghcr.io/resmoio/kubernetes-event-exporter
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: v1.1
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/kubernetes-event-exporter/values.yaml
+++ b/charts/kubernetes-event-exporter/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: ghcr.io/resmoio/kubernetes-event-exporter
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: latest
+  tag: v1.1
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
this pr also fixes the labels of the resources it creates

fixes #77 

```
 metadata:
+  labels:
+    app.kubernetes.io/instance: kubernetes-event-exporter
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: event-exporter
+    app.kubernetes.io/version: "1.1"
+    helm.sh/chart: kubernetes-event-exporter-0.2.0
   name: event-exporter
```

```
-        image: ghcr.io/resmoio/kubernetes-event-exporter:latest
+        image: ghcr.io/resmoio/kubernetes-event-exporter:v1.1
```