### PR TITLE
New probes and Kubernetes Service resource

### DIFF
--- a/charts/kubernetes-event-exporter/Chart.yaml
+++ b/charts/kubernetes-event-exporter/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kubernetes-event-exporter/templates/deployment.yaml
+++ b/charts/kubernetes-event-exporter/templates/deployment.yaml
@@ -31,17 +31,17 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            - name: metrics
+            - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /metrics
-              port: metrics
+              path: /-/healthy
+              port: http
           readinessProbe:
             httpGet:
-              path: /metrics
-              port: metrics
+              path: /-/ready
+              port: http
           args:
             - -conf=/data/config.yaml
           volumeMounts:

--- a/charts/kubernetes-event-exporter/templates/service.yaml
+++ b/charts/kubernetes-event-exporter/templates/service.yaml
@@ -1,0 +1,14 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ include "kubernetes-event-exporter.fullname" . }}
+  namespace: {{ include "kubernetes-event-exporter.namespace" . }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      protocol: TCP
+  selector:
+    {{- include "kubernetes-event-exporter.selectorLabels" . | indent 4 }}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,10 +1,12 @@
 package metrics
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/prometheus/common/version"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -21,7 +23,25 @@ func Init(addr string) {
 	// Setup the prometheus metrics machinery
 	// Add Go module build info.
 	prometheus.MustRegister(collectors.NewBuildInfoCollector())
-
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`<html>
+             <head><title>Kubernetes Events Exporter</title></head>
+             <body>
+             <h1>Kubernetes Events Exporter</h1>
+             <p><a href='metrics'>Metrics</a></p>
+			 <h2>Build</h2>
+             <pre>` + version.Info() + ` ` + version.BuildContext() + `</pre>
+             </body>
+             </html>`))
+	})
+	http.HandleFunc("/-/healthy", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, "OK")
+	})
+	http.HandleFunc("/-/ready", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, "OK")
+	})
 	// Expose the registered metrics via HTTP.
 	http.Handle("/metrics", promhttp.HandlerFor(
 		prometheus.DefaultGatherer,


### PR DESCRIPTION
Add 3 routes:
- `/` a landing page
- `/-/healthy` and `/-/ready` for Kubernetes probes

Add a Kubernetes `Service` resource