### PR TITLE
added capability to use elasticsearch datastreams

### DIFF
--- a/pkg/kube/event.go
+++ b/pkg/kube/event.go
@@ -12,6 +12,7 @@ type EnhancedEvent struct {
 	corev1.Event   `json:",inline"`
 	ClusterName    string                  `json:"clusterName"`
 	InvolvedObject EnhancedObjectReference `json:"involvedObject"`
+	Timestamp      time.Time               `json:"@timestamp"`
 }
 
 // DeDot replaces all dots in the labels and annotations with underscores. This is required for example in the
@@ -47,6 +48,7 @@ type EnhancedObjectReference struct {
 // ToJSON does not return an error because we are %99 confident it is JSON serializable.
 // TODO(makin) Is it a bad practice? It's open to discussion.
 func (e *EnhancedEvent) ToJSON() []byte {
+	e.Timestamp = e.FirstTimestamp.Time
 	b, _ := json.Marshal(e)
 	return b
 }


### PR DESCRIPTION
While taking kubernetes-event-explorer into use, I stumbled into an issue, where kubernetes-event-explorer logs:
> {"level":"error","time":"2023-05-26T12:55:34Z","caller":"/app/pkg/sinks/elasticsearch.go:144","message":"Indexing failed: {\"error\":{\"root_cause\":[{\"type\":\"mapper_parsing_exception\",\"reason\":\"failed to parse\"}],\"type\":\"mapper_parsing_exception\",\"reason\":\"failed to parse\",\"caused_by\":{\"type\":\"illegal_argument_exception\",\"reason\":\"data stream timestamp field [@timestamp] is missing\"}},\"status\":400}"}

After looking for ways to fix this, I stumbled into https://github.com/opsgenie/kubernetes-event-exporter/pull/165 and it solved the problem for my local build.