### PR TITLE
feat: improve error handling in teams sink for http error 429 response

### DIFF
--- a/pkg/sinks/teams.go
+++ b/pkg/sinks/teams.go
@@ -2,13 +2,14 @@ package sinks
 
 import (
 	"bytes"
-	"fmt"
-	"encoding/json"
 	"context"
-	"errors"
-	"github.com/resmoio/kubernetes-event-exporter/pkg/kube"
-	"io/ioutil"
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
+	"strings"
+
+	"github.com/resmoio/kubernetes-event-exporter/pkg/kube"
 )
 
 type TeamsConfig struct {
@@ -59,11 +60,15 @@ func (w *Teams) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
 	}
 
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	message := string(body)
 
-	// TODO: make this prettier please
 	if resp.StatusCode != http.StatusOK {
-		return errors.New("not 200: " + string(body))
+		return fmt.Errorf("not 200: %s", message)
+	}
+	// see: https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using?tabs=cURL#rate-limiting-for-connectors
+	if strings.Contains(message, "Microsoft Teams endpoint returned HTTP error 429") {
+		return fmt.Errorf("rate limited: %s", message)
 	}
 
 	return nil

--- a/pkg/sinks/teams_test.go
+++ b/pkg/sinks/teams_test.go
@@ -1,0 +1,36 @@
+package sinks
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/resmoio/kubernetes-event-exporter/pkg/kube"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTeams_Send(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+	client := Teams{cfg: &TeamsConfig{Endpoint: ts.URL}}
+
+	err := client.Send(context.Background(), &kube.EnhancedEvent{})
+
+	assert.NoError(t, err)
+}
+
+func TestTeams_Send_WhenTeamsReturnsRateLimited(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Webhook message delivery failed with error: Microsoft Teams endpoint returned HTTP error 429 with ContextId tcid=0"))
+	}))
+	defer ts.Close()
+	client := Teams{cfg: &TeamsConfig{Endpoint: ts.URL}}
+
+	err := client.Send(context.Background(), &kube.EnhancedEvent{})
+
+	assert.ErrorContains(t, err, "rate limited")
+}


### PR DESCRIPTION
Improve error handling in the teams sink to return an error when the Teams endpoint responds with HTTP error 429.

see: https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using?tabs=cURL#rate-limiting-for-connectors