### PR TITLE
Adopt Pod Security Admission "restricted" policy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN CGO_ENABLED=0 GOOS=linux GO11MODULE=on go build -a -o /main .
 FROM gcr.io/distroless/static:nonroot
 COPY --from=builder --chown=nonroot:nonroot /main /kubernetes-event-exporter
 
-USER nonroot
+# https://github.com/GoogleContainerTools/distroless/blob/main/base/base.bzl#L8C1-L9C1
+USER 65532
 
 ENTRYPOINT ["/kubernetes-event-exporter"]

--- a/deploy/00-roles.yaml
+++ b/deploy/00-roles.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: monitoring
+  labels:
+    pod-security.kubernetes.io/restricted: enforce
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/deploy/02-deployment.yaml
+++ b/deploy/02-deployment.yaml
@@ -16,6 +16,10 @@ spec:
         prometheus.io/path: '/metrics'
     spec:
       serviceAccountName: event-exporter
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: event-exporter
           # The good practice would be to pin the version. This is just a reference so that we don't
@@ -27,6 +31,10 @@ spec:
           volumeMounts:
             - mountPath: /data
               name: cfg
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
       volumes:
         - name: cfg
           configMap:


### PR DESCRIPTION
This PR updates manifests to adopt Pod Security Admission "restricted" policy.

The event-exporter does not need strong privileges to run, so it can satisfy the "restricted" policy.