### PR TITLE
Fix "template: kubernetes-event-exporter/templates/_helpers.tpl:14:14…

### DIFF
--- a/charts/kubernetes-event-exporter/templates/deployment.yaml
+++ b/charts/kubernetes-event-exporter/templates/deployment.yaml
@@ -10,9 +10,9 @@ spec:
       {{- include "kubernetes-event-exporter.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:


### PR DESCRIPTION
I tried to install kubernetes-event-exporter chart of master branch   into  Kubernetes 1.21 , but I got  a nil exception complaint and found that the current context had been changed with 'with'.

`…: executing "kubernetes-event-exporter.fullname" at <.Values.fullnameOverride>: nil pointer evaluating interface {}.fullnameOverride" while try to install helm charts`