### PR TITLE
sink/slack: Use `GetString` for color

### DIFF
--- a/pkg/sinks/slack.go
+++ b/pkg/sinks/slack.go
@@ -73,7 +73,10 @@ func (s *SlackSink) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
 			}
 		}
 		if s.cfg.Color != "" {
-			slackAttachment.Color = s.cfg.Color
+			slackAttachment.Color, err = GetString(ev, s.cfg.Color)
+			if err != nil {
+				return err
+			}
 		}
 		if s.cfg.Title != "" {
 			slackAttachment.Title, err = GetString(ev, s.cfg.Title)


### PR DESCRIPTION
This PR changes to use `GetString` for color of slack sink.

I want to change the color by `.Type` as follows:

```yaml
    color: '{{ if eq .Type "Warning" }}danger{{ else }}good{{ end }}'
```