### PR TITLE
Introduce omitLookup config flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ func main() {
 		}
 	}
 
-	w := kube.NewEventWatcher(kubecfg, cfg.Namespace, cfg.MaxEventAgeSeconds, metricsStore, onEvent)
+	w := kube.NewEventWatcher(kubecfg, cfg.Namespace, cfg.MaxEventAgeSeconds, metricsStore, onEvent, cfg.OmitLookup)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	leaderLost := make(chan bool)

--- a/pkg/exporter/config.go
+++ b/pkg/exporter/config.go
@@ -26,7 +26,8 @@ type Config struct {
 	Receivers          []sinks.ReceiverConfig    `yaml:"receivers"`
 	KubeQPS            float32                   `yaml:"kubeQPS,omitempty"`
 	KubeBurst          int                       `yaml:"kubeBurst,omitempty"`
-	MetricsNamePrefix  string					 `yaml:"metricsNamePrefix,omitempty"`
+	MetricsNamePrefix  string                    `yaml:"metricsNamePrefix,omitempty"`
+	OmitLookup         bool                      `yaml:"omitLookup,omitempty"`
 }
 
 func (c *Config) Validate() error {


### PR DESCRIPTION
This flag wraps the Label and Annotation lookup to prevent API throttling. This helps when there is a huge amount of events and you see messages like
```
I0801 13:46:27.929629       1 request.go:690] Waited for 36.597358359s due to client-side throttling, not priority and fairness, request: GET:https://XXX.XXX.XXX.XXX:443/apis/XXXXXXXXXXX/v1beta1
```