### PR TITLE
Remove namespace configuration from deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Head on to `deploy/` folder and apply the YAMLs in the given filename order. Do 
 
 Deploy with Kustomize by Git ref (i.e., commit sha, tag, or branch).
 
+Create namespace before deployment:
+
+```console
+kubectl create namespace monitoring
+```
+
 ```yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/deploy/00-roles.yaml
+++ b/deploy/00-roles.yaml
@@ -1,11 +1,4 @@
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: monitoring
-  labels:
-    pod-security.kubernetes.io/restricted: enforce
----
-apiVersion: v1
 kind: ServiceAccount
 metadata:
   namespace: monitoring


### PR DESCRIPTION
While I'm myself miserable piece of shit, deleting whole namespace on `kubectl delete --kustomize .`. I would not have done it if it wasn't described here.

I think the name is pretty common, moreover the namespace is not what tools should describe when deploying to k8s. Instead it should probably be handled on the higher level of abstraction.