### PR TITLE
add ProcessUpdateEvent trigger to controll whether sent the event to the recivers when the event is update

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,17 @@ to keep the config file clean of secrets.
     maxEventAgeSeconds: 60
     ```
 
+## Ignore event update
+if an event occur many times, It will only update the event fields like ```count``` and ```lastTimestamp```.
+By default ```kubernetes-event-exporter``` will ignore the eventUpdate and will not sent to the recivers.
+If you Don't want to miss every event,you can use trigger ```processUpdateEvent``` to controll whether sent the event to the recivers.
+```azure
+processUpdateEvent true|false  (default false)
+
+true: sent every matching event to the recivers including when the event updated 
+false: ignore the event updted
+```
+
 ### Opsgenie
 
 [Opsgenie](https://www.opsgenie.com) is an alerting and on-call management tool. kubernetes-event-exporter can push to

--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ func main() {
 		}
 	}
 
-	w := kube.NewEventWatcher(kubecfg, cfg.Namespace, cfg.MaxEventAgeSeconds, metricsStore, onEvent, cfg.OmitLookup)
+	w := kube.NewEventWatcher(kubecfg, cfg.Namespace, cfg.MaxEventAgeSeconds, cfg.ProcessUpdateEvent, metricsStore, onEvent, cfg.OmitLookup)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	leaderLost := make(chan bool)

--- a/pkg/exporter/config.go
+++ b/pkg/exporter/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	KubeBurst          int                       `yaml:"kubeBurst,omitempty"`
 	MetricsNamePrefix  string                    `yaml:"metricsNamePrefix,omitempty"`
 	OmitLookup         bool                      `yaml:"omitLookup,omitempty"`
+	ProcessUpdateEvent bool                      `yaml:"processUpdateEvent,omitempty"`
 }
 
 func (c *Config) Validate() error {


### PR DESCRIPTION
if an event occur many times, It will only update the event fields like ```count``` and ```lastTimestamp```.
By default ```kubernetes-event-exporter``` will ignore the eventUpdate and will not sent to the recivers.
If you Don't want to miss every event,you can use trigger ```processUpdateEvent``` to controll whether sent the event to the recivers.