### PR TITLE
fix drop example to a valid regexp

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -10,13 +10,13 @@ route:
     # This route allows dumping all events because it has no fields to match and no drop rules.
     - match:
         - receiver: "dump"
-    # This starts another route, drops all the events in *test* namespaces and Normal events
+    # This starts another route, drops all the events from all namespaces containing 'test' and Normal events
     # for capturing critical events
     - match:
         - receiver: "alert"
         - receiver: "pipe"
       drop:
-        - namespace: "*test*"
+        - namespace: ".*test.*" # should be a valid regexp syntax
         - type: "Normal"
           minCount: 5
           apiVersion: "*beta*"


### PR DESCRIPTION
The config example includes an invalid regexp to drop namespaces.
This PR aims to fix that.