### PR TITLE
Add core API group in ClusterRole

### DIFF
--- a/deploy/00-roles.yaml
+++ b/deploy/00-roles.yaml
@@ -22,6 +22,6 @@ kind: ClusterRole
 metadata:
   name: event-exporter
 rules:
-- apiGroups: ["*"]
+- apiGroups: ["*", ""]
   resources: ["*"]
   verbs: ["get", "watch", "list"]


### PR DESCRIPTION
with existing rules I still see errors like:
```
{"level":"error","error":"name is required","time":"2023-10-26T21:25:06Z","message":"Cannot list labels of the object"}
{"level":"error","error":"name is required","time":"2023-10-26T21:25:06Z","message":"Cannot list annotations of the object"}
```
Adding core API group "" fixed the issue