### PR TITLE
al sinks add the trigger to controll sent or ignore event update,and make the code gci-ed

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,24 @@ receivers:
 * A route can have many sub-routes, forming a tree.
 * Routing starts from the root route.
 
+## sent or ignore event update
+if an event occur many times, It will only update the event fields like ```count``` and ```lastTimestamp```.
+By default ```kubernetes-event-exporter``` will ignore the eventUpdate and will not sent to the recivers.
+If you Don't want to miss every event,you can use trigger ```sentUpdateEvent``` configurated in each sink to controll whether sent the event to the reciver.
+```azure
+sentUpdateEvent true|false  (default false)
+true: sent every matching event to the reciver including when the event updated 
+false: ignore the event updted
+```
+
+for example:
+```azure
+receivers:
+  - name: "dump"
+    stdout: 
+      sentUpdateEvent: true
+```
+
 ## Using Secrets
 
 In your config file, you can refer to environment variables as `${API_KEY}` therefore you can use ConfigMap or Secrets 

--- a/pkg/kube/event.go
+++ b/pkg/kube/event.go
@@ -11,6 +11,7 @@ import (
 
 type EnhancedEvent struct {
 	corev1.Event   `json:",inline"`
+	IsUpdateEvent  bool                    `json:"isUpdateEvent"`
 	ClusterName    string                  `json:"clusterName"`
 	InvolvedObject EnhancedObjectReference `json:"involvedObject"`
 }

--- a/pkg/sinks/elasticsearch.go
+++ b/pkg/sinks/elasticsearch.go
@@ -18,6 +18,7 @@ import (
 )
 
 type ElasticsearchConfig struct {
+	SentUpdateEvent bool `yaml:"sentUpdateEvent,omitempty"`
 	// Connection specific
 	Hosts    []string          `yaml:"hosts"`
 	Username string            `yaml:"username"`
@@ -97,6 +98,10 @@ func formatIndexName(pattern string, when time.Time) string {
 }
 
 func (e *Elasticsearch) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
+	// skip update event
+	if ev.IsUpdateEvent && !e.cfg.SentUpdateEvent {
+		return nil
+	}
 	var toSend []byte
 
 	if e.cfg.DeDot {

--- a/pkg/sinks/eventbridge.go
+++ b/pkg/sinks/eventbridge.go
@@ -13,11 +13,12 @@ import (
 )
 
 type EventBridgeConfig struct {
-	DetailType   string                 `yaml:"detailType"`
-	Details      map[string]interface{} `yaml:"details"`
-	Source       string                 `yaml:"source"`
-	EventBusName string                 `yaml:"eventBusName"`
-	Region       string                 `yaml:"region"`
+	SentUpdateEvent bool                   `yaml:"sentUpdateEvent,omitempty"`
+	DetailType      string                 `yaml:"detailType"`
+	Details         map[string]interface{} `yaml:"details"`
+	Source          string                 `yaml:"source"`
+	EventBusName    string                 `yaml:"eventBusName"`
+	Region          string                 `yaml:"region"`
 }
 
 type EventBridgeSink struct {
@@ -49,6 +50,10 @@ func NewEventBridgeSink(cfg *EventBridgeConfig) (Sink, error) {
 }
 
 func (s *EventBridgeSink) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
+	// skip update event
+	if ev.IsUpdateEvent && !s.cfg.SentUpdateEvent {
+		return nil
+	}
 	log.Info().Msg("Sending event to EventBridge ")
 	var toSend string
 	if s.cfg.Details != nil {

--- a/pkg/sinks/firehose.go
+++ b/pkg/sinks/firehose.go
@@ -11,6 +11,7 @@ import (
 )
 
 type FirehoseConfig struct {
+	SentUpdateEvent    bool                   `yaml:"sentUpdateEvent,omitempty"`
 	DeliveryStreamName string                 `yaml:"deliveryStreamName"`
 	Region             string                 `yaml:"region"`
 	Layout             map[string]interface{} `yaml:"layout"`
@@ -38,6 +39,10 @@ func NewFirehoseSink(cfg *FirehoseConfig) (Sink, error) {
 }
 
 func (f *FirehoseSink) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
+	// skip update event
+	if ev.IsUpdateEvent && !f.cfg.SentUpdateEvent {
+		return nil
+	}
 	var toSend []byte
 
 	if f.cfg.DeDot {

--- a/pkg/sinks/inmemory.go
+++ b/pkg/sinks/inmemory.go
@@ -6,7 +6,8 @@ import (
 )
 
 type InMemoryConfig struct {
-	Ref *InMemory
+	SentUpdateEvent bool `yaml:"sentUpdateEvent,omitempty"`
+	Ref             *InMemory
 }
 
 type InMemory struct {
@@ -15,6 +16,10 @@ type InMemory struct {
 }
 
 func (i *InMemory) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
+	// skip update event
+	if ev.IsUpdateEvent && !i.Config.SentUpdateEvent {
+		return nil
+	}
 	i.Events = append(i.Events, ev)
 	return nil
 }
@@ -22,5 +27,3 @@ func (i *InMemory) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
 func (i *InMemory) Close() {
 	// No-op
 }
-
-

--- a/pkg/sinks/kafka.go
+++ b/pkg/sinks/kafka.go
@@ -14,6 +14,7 @@ import (
 
 // KafkaConfig is the Kafka producer configuration
 type KafkaConfig struct {
+	SentUpdateEvent  bool                   `yaml:"sentUpdateEvent,omitempty"`
 	Topic            string                 `yaml:"topic"`
 	Brokers          []string               `yaml:"brokers"`
 	Layout           map[string]interface{} `yaml:"layout"`
@@ -82,6 +83,10 @@ func NewKafkaSink(cfg *KafkaConfig) (Sink, error) {
 
 // Send an event to Kafka synchronously
 func (k *KafkaSink) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
+	// skip update event
+	if ev.IsUpdateEvent && !k.cfg.SentUpdateEvent {
+		return nil
+	}
 	var toSend []byte
 
 	if k.cfg.Layout != nil {

--- a/pkg/sinks/kinesis.go
+++ b/pkg/sinks/kinesis.go
@@ -10,9 +10,10 @@ import (
 )
 
 type KinesisConfig struct {
-	StreamName string                 `yaml:"streamName"`
-	Region     string                 `yaml:"region"`
-	Layout     map[string]interface{} `yaml:"layout"`
+	SentUpdateEvent bool                   `yaml:"sentUpdateEvent,omitempty"`
+	StreamName      string                 `yaml:"streamName"`
+	Region          string                 `yaml:"region"`
+	Layout          map[string]interface{} `yaml:"layout"`
 }
 
 type KinesisSink struct {
@@ -35,6 +36,10 @@ func NewKinesisSink(cfg *KinesisConfig) (Sink, error) {
 }
 
 func (k *KinesisSink) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
+	// skip update event
+	if ev.IsUpdateEvent && !k.cfg.SentUpdateEvent {
+		return nil
+	}
 	var toSend []byte
 
 	if k.cfg.Layout != nil {

--- a/pkg/sinks/loki.go
+++ b/pkg/sinks/loki.go
@@ -7,11 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"github.com/resmoio/kubernetes-event-exporter/pkg/kube"
+	"github.com/rs/zerolog/log"
 	"io/ioutil"
 	"net/http"
 	"strconv"
 	"time"
-	"github.com/rs/zerolog/log"
 )
 
 type promtailStream struct {
@@ -24,11 +24,12 @@ type LokiMsg struct {
 }
 
 type LokiConfig struct {
-	Layout       map[string]interface{} `yaml:"layout"`
-	StreamLabels map[string]string      `yaml:"streamLabels"`
-	TLS          TLS                    `yaml:"tls"`
-	URL          string                 `yaml:"url"`
-	Headers      map[string]string      `yaml:"headers"`
+	SentUpdateEvent bool                   `yaml:"sentUpdateEvent,omitempty"`
+	Layout          map[string]interface{} `yaml:"layout"`
+	StreamLabels    map[string]string      `yaml:"streamLabels"`
+	TLS             TLS                    `yaml:"tls"`
+	URL             string                 `yaml:"url"`
+	Headers         map[string]string      `yaml:"headers"`
 }
 
 type Loki struct {
@@ -52,6 +53,10 @@ func generateTimestamp() string {
 }
 
 func (l *Loki) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
+	// skip update event
+	if ev.IsUpdateEvent && !l.cfg.SentUpdateEvent {
+		return nil
+	}
 	eventBody, err := serializeEventWithLayout(l.cfg.Layout, ev)
 	if err != nil {
 		return err

--- a/pkg/sinks/opensearch.go
+++ b/pkg/sinks/opensearch.go
@@ -18,6 +18,7 @@ import (
 )
 
 type OpenSearchConfig struct {
+	SentUpdateEvent bool `yaml:"sentUpdateEvent,omitempty"`
 	// Connection specific
 	Hosts    []string `yaml:"hosts"`
 	Username string   `yaml:"username"`
@@ -84,6 +85,10 @@ func osFormatIndexName(pattern string, when time.Time) string {
 }
 
 func (e *OpenSearch) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
+	// skip update event
+	if ev.IsUpdateEvent && !e.cfg.SentUpdateEvent {
+		return nil
+	}
 	var toSend []byte
 
 	if e.cfg.DeDot {

--- a/pkg/sinks/opscenter.go
+++ b/pkg/sinks/opscenter.go
@@ -14,6 +14,7 @@ import (
 
 // OpsCenterConfig is the configuration of the Sink.
 type OpsCenterConfig struct {
+	SentUpdateEvent bool              `yaml:"sentUpdateEvent,omitempty"`
 	Category        string            `yaml:"category"`
 	Description     string            `yaml:"description"`
 	Notifications   []string          `yaml:"notifications"`
@@ -51,6 +52,10 @@ func NewOpsCenterSink(cfg *OpsCenterConfig) (Sink, error) {
 
 // Send ...
 func (s *OpsCenterSink) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
+	// skip update event
+	if ev.IsUpdateEvent && !s.cfg.SentUpdateEvent {
+		return nil
+	}
 	oi := ssm.CreateOpsItemInput{}
 	t, err := GetString(ev, s.cfg.Title)
 	if err != nil {

--- a/pkg/sinks/opsgenie.go
+++ b/pkg/sinks/opsgenie.go
@@ -2,20 +2,21 @@ package sinks
 
 import (
 	"context"
-	"github.com/resmoio/kubernetes-event-exporter/pkg/kube"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/alert"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
+	"github.com/resmoio/kubernetes-event-exporter/pkg/kube"
 )
 
 type OpsgenieConfig struct {
-	ApiKey      string            `yaml:"apiKey"`
-	URL         client.ApiUrl     `yaml:"URL"`
-	Priority    string            `yaml:"priority"`
-	Message     string            `yaml:"message"`
-	Alias       string            `yaml:"alias"`
-	Description string            `yaml:"description"`
-	Tags        []string          `yaml:"tags"`
-	Details     map[string]string `yaml:"details"`
+	SentUpdateEvent bool              `yaml:"sentUpdateEvent,omitempty"`
+	ApiKey          string            `yaml:"apiKey"`
+	URL             client.ApiUrl     `yaml:"URL"`
+	Priority        string            `yaml:"priority"`
+	Message         string            `yaml:"message"`
+	Alias           string            `yaml:"alias"`
+	Description     string            `yaml:"description"`
+	Tags            []string          `yaml:"tags"`
+	Details         map[string]string `yaml:"details"`
 }
 
 type OpsgenieSink struct {
@@ -48,6 +49,10 @@ func NewOpsgenieSink(config *OpsgenieConfig) (Sink, error) {
 }
 
 func (o *OpsgenieSink) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
+	// skip update event
+	if ev.IsUpdateEvent && !o.cfg.SentUpdateEvent {
+		return nil
+	}
 	request := alert.CreateAlertRequest{
 		Priority: alert.Priority(o.cfg.Priority),
 	}

--- a/pkg/sinks/pipe.go
+++ b/pkg/sinks/pipe.go
@@ -10,9 +10,10 @@ import (
 )
 
 type PipeConfig struct {
-	Path   string                 `yaml:"path"`
+	SentUpdateEvent bool   `yaml:"sentUpdateEvent,omitempty"`
+	Path            string `yaml:"path"`
 	// DeDot all labels and annotations in the event. For both the event and the involvedObject
-	DeDot       bool              `yaml:"deDot"`
+	DeDot  bool                   `yaml:"deDot"`
 	Layout map[string]interface{} `yaml:"layout"`
 }
 
@@ -44,6 +45,10 @@ func (f *Pipe) Close() {
 }
 
 func (f *Pipe) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
+	// skip update event
+	if ev.IsUpdateEvent && !f.cfg.SentUpdateEvent {
+		return nil
+	}
 	if f.cfg.DeDot {
 		de := ev.DeDot()
 		ev = &de

--- a/pkg/sinks/pubsub.go
+++ b/pkg/sinks/pubsub.go
@@ -9,6 +9,7 @@ import (
 )
 
 type PubsubConfig struct {
+	SentUpdateEvent bool   `yaml:"sentUpdateEvent,omitempty"`
 	GcloudProjectId string `yaml:"gcloud_project_id"`
 	Topic           string `yaml:"topic"`
 	CreateTopic     bool   `yaml:"create_topic"`
@@ -46,6 +47,10 @@ func NewPubsubSink(cfg *PubsubConfig) (Sink, error) {
 }
 
 func (ps *PubsubSink) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
+	// skip update event
+	if ev.IsUpdateEvent && !ps.cfg.SentUpdateEvent {
+		return nil
+	}
 	msg := &pubsub.Message{
 		Data: ev.ToJSON(),
 	}

--- a/pkg/sinks/slack.go
+++ b/pkg/sinks/slack.go
@@ -10,14 +10,15 @@ import (
 )
 
 type SlackConfig struct {
-	Token      string            `yaml:"token"`
-	Channel    string            `yaml:"channel"`
-	Message    string            `yaml:"message"`
-	Color      string            `yaml:"color"`
-	Footer     string            `yaml:"footer"`
-	Title      string            `yaml:"title"`
-	AuthorName string            `yaml:"author_name"`
-	Fields     map[string]string `yaml:"fields"`
+	SentUpdateEvent bool              `yaml:"sentUpdateEvent,omitempty"`
+	Token           string            `yaml:"token"`
+	Channel         string            `yaml:"channel"`
+	Message         string            `yaml:"message"`
+	Color           string            `yaml:"color"`
+	Footer          string            `yaml:"footer"`
+	Title           string            `yaml:"title"`
+	AuthorName      string            `yaml:"author_name"`
+	Fields          map[string]string `yaml:"fields"`
 }
 
 type SlackSink struct {
@@ -33,6 +34,10 @@ func NewSlackSink(cfg *SlackConfig) (Sink, error) {
 }
 
 func (s *SlackSink) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
+	// skip update event
+	if ev.IsUpdateEvent && !s.cfg.SentUpdateEvent {
+		return nil
+	}
 	channel, err := GetString(ev, s.cfg.Channel)
 	if err != nil {
 		return err

--- a/pkg/sinks/sns.go
+++ b/pkg/sinks/sns.go
@@ -9,9 +9,10 @@ import (
 )
 
 type SNSConfig struct {
-	TopicARN string                 `yaml:"topicARN"`
-	Region   string                 `yaml:"region"`
-	Layout   map[string]interface{} `yaml:"layout"`
+	SentUpdateEvent bool                   `yaml:"sentUpdateEvent,omitempty"`
+	TopicARN        string                 `yaml:"topicARN"`
+	Region          string                 `yaml:"region"`
+	Layout          map[string]interface{} `yaml:"layout"`
 }
 
 type SNSSink struct {

--- a/pkg/sinks/sqs.go
+++ b/pkg/sinks/sqs.go
@@ -9,9 +9,10 @@ import (
 )
 
 type SQSConfig struct {
-	QueueName string                 `yaml:"queueName"`
-	Region    string                 `yaml:"region"`
-	Layout    map[string]interface{} `yaml:"layout"`
+	SentUpdateEvent bool                   `yaml:"sentUpdateEvent,omitempty"`
+	QueueName       string                 `yaml:"queueName"`
+	Region          string                 `yaml:"region"`
+	Layout          map[string]interface{} `yaml:"layout"`
 }
 
 type SQSSink struct {
@@ -45,6 +46,10 @@ func NewSQSSink(cfg *SQSConfig) (Sink, error) {
 }
 
 func (s *SQSSink) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
+	// skip update event
+	if ev.IsUpdateEvent && !s.cfg.SentUpdateEvent {
+		return nil
+	}
 	toSend, e := serializeEventWithLayout(s.cfg.Layout, ev)
 	if e != nil {
 		return e

--- a/pkg/sinks/stdout.go
+++ b/pkg/sinks/stdout.go
@@ -11,6 +11,7 @@ import (
 )
 
 type StdoutConfig struct {
+	SentUpdateEvent bool `yaml:"sentUpdateEvent,omitempty"`
 	// DeDot all labels and annotations in the event. For both the event and the involvedObject
 	DeDot  bool                   `yaml:"deDot"`
 	Layout map[string]interface{} `yaml:"layout"`
@@ -41,6 +42,10 @@ func (f *Stdout) Close() {
 }
 
 func (f *Stdout) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
+	// skip update event
+	if ev.IsUpdateEvent && !f.cfg.SentUpdateEvent {
+		return nil
+	}
 	if f.cfg.DeDot {
 		de := ev.DeDot()
 		ev = &de

--- a/pkg/sinks/teams.go
+++ b/pkg/sinks/teams.go
@@ -13,9 +13,10 @@ import (
 )
 
 type TeamsConfig struct {
-	Endpoint string                 `yaml:"endpoint"`
-	Layout   map[string]interface{} `yaml:"layout"`
-	Headers  map[string]string      `yaml:"headers"`
+	SentUpdateEvent bool                   `yaml:"sentUpdateEvent,omitempty"`
+	Endpoint        string                 `yaml:"endpoint"`
+	Layout          map[string]interface{} `yaml:"layout"`
+	Headers         map[string]string      `yaml:"headers"`
 }
 
 func NewTeamsSink(cfg *TeamsConfig) (Sink, error) {
@@ -31,6 +32,11 @@ func (w *Teams) Close() {
 }
 
 func (w *Teams) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
+	// skip update event
+	if ev.IsUpdateEvent && !w.cfg.SentUpdateEvent {
+		return nil
+	}
+
 	event, err := serializeEventWithLayout(w.cfg.Layout, ev)
 	if err != nil {
 		return err

--- a/pkg/sinks/webhook.go
+++ b/pkg/sinks/webhook.go
@@ -13,10 +13,11 @@ import (
 )
 
 type WebhookConfig struct {
-	Endpoint string                 `yaml:"endpoint"`
-	TLS      TLS                    `yaml:"tls"`
-	Layout   map[string]interface{} `yaml:"layout"`
-	Headers  map[string]string      `yaml:"headers"`
+	SentUpdateEvent bool                   `yaml:"sentUpdateEvent,omitempty"`
+	Endpoint        string                 `yaml:"endpoint"`
+	TLS             TLS                    `yaml:"tls"`
+	Layout          map[string]interface{} `yaml:"layout"`
+	Headers         map[string]string      `yaml:"headers"`
 }
 
 func NewWebhook(cfg *WebhookConfig) (Sink, error) {
@@ -40,6 +41,11 @@ func (w *Webhook) Close() {
 }
 
 func (w *Webhook) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
+	// skip update event
+	if ev.IsUpdateEvent && !w.cfg.SentUpdateEvent {
+		return nil
+	}
+
 	reqBody, err := serializeEventWithLayout(w.cfg.Layout, ev)
 	if err != nil {
 		return err


### PR DESCRIPTION
if an event occur many times, It will only update the event fields like ```count``` and ```lastTimestamp```.
By default ```kubernetes-event-exporter``` will ignore the eventUpdate and will not sent to the recivers.
If you Don't want to miss every event,you can use trigger ```sentUpdateEvent``` configurated in each sink to controll whether sent the event to the reciver.
