### PR TITLE
fix: Use correct transport with loki

### DIFF
--- a/pkg/sinks/loki.go
+++ b/pkg/sinks/loki.go
@@ -6,11 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/resmoio/kubernetes-event-exporter/pkg/kube"
 	"io/ioutil"
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/resmoio/kubernetes-event-exporter/pkg/kube"
 	"github.com/rs/zerolog/log"
 )
 
@@ -86,6 +87,7 @@ func (l *Loki) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
 	}
 
 	client := http.DefaultClient
+	client.Transport = l.transport
 	resp, err := client.Do(req)
 	if err != nil {
 		return err


### PR DESCRIPTION
This should resolve issues with the loki sink not respecting the tls configuration. I updated this to match what the webhook sink is doing when configuring its transport.

fixes #127