### PR TITLE
feat: support metrics of events matched

### DIFF
--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func main() {
 	kubecfg.Burst = cfg.KubeBurst
 
 	metrics.Init(*addr, *tlsConf)
-	metricsStore := metrics.NewMetricsStore(cfg.MetricsNamePrefix)
+	metricsStore := metrics.NewMetricsStore(cfg.MetricsNamePrefix, cfg.Route.GetMatchNames())
 
 	engine := exporter.NewEngine(&cfg, &exporter.ChannelBasedReceiverRegistry{MetricsStore: metricsStore})
 	onEvent := engine.OnEvent

--- a/pkg/exporter/channel_registry.go
+++ b/pkg/exporter/channel_registry.go
@@ -22,10 +22,15 @@ type ChannelBasedReceiverRegistry struct {
 	MetricsStore *metrics.Store
 }
 
-func (r *ChannelBasedReceiverRegistry) SendEvent(name string, event *kube.EnhancedEvent) {
+func (r *ChannelBasedReceiverRegistry) SendEvent(name string, event *kube.EnhancedEvent, ruleName string) {
 	ch := r.ch[name]
 	if ch == nil {
 		log.Error().Str("name", name).Msg("There is no channel")
+	}
+	if counter, ok := r.MetricsStore.EventsMatched[ruleName]; ok {
+		counter.Inc()
+	} else {
+		r.MetricsStore.EventsMatched[metrics.DefaultRuleName].Inc()
 	}
 
 	go func() {

--- a/pkg/exporter/receivers.go
+++ b/pkg/exporter/receivers.go
@@ -7,7 +7,7 @@ import (
 
 // ReceiverRegistry registers a receiver with the appropriate sink
 type ReceiverRegistry interface {
-	SendEvent(string, *kube.EnhancedEvent)
+	SendEvent(string, *kube.EnhancedEvent, string)
 	Register(string, sinks.Sink)
 	Close()
 }

--- a/pkg/exporter/route.go
+++ b/pkg/exporter/route.go
@@ -24,7 +24,7 @@ func (r *Route) ProcessEvent(ev *kube.EnhancedEvent, registry ReceiverRegistry) 
 	for _, rule := range r.Match {
 		if rule.MatchesEvent(ev) {
 			if rule.Receiver != "" {
-				registry.SendEvent(rule.Receiver, ev)
+				registry.SendEvent(rule.Receiver, ev, rule.Name)
 				// Send the event down the hole
 			}
 		} else {
@@ -38,4 +38,17 @@ func (r *Route) ProcessEvent(ev *kube.EnhancedEvent, registry ReceiverRegistry) 
 			subRoute.ProcessEvent(ev, registry)
 		}
 	}
+}
+
+// get names of match rules
+func (r *Route) GetMatchNames() []string {
+	var names []string
+	for _, route := range r.Routes {
+		for _, rule := range route.Match {
+			if rule.Name != "" {
+				names = append(names, rule.Name)
+			}
+		}
+	}
+	return names
 }

--- a/pkg/exporter/rule.go
+++ b/pkg/exporter/rule.go
@@ -16,6 +16,7 @@ func matchString(pattern, s string) bool {
 
 // Rule is for matching an event
 type Rule struct {
+	Name 	    string `yaml:"name"`
 	Labels      map[string]string
 	Annotations map[string]string
 	Message     string


### PR DESCRIPTION
Now we have metrics of `events_sent`, which means total calculation of events sent from api-server and received by the event-exporter. But we don't have metrics to show how many events matched and sent to receivers we defined.

This PR supports metrics of events-matched metrics. It will create metrics named `event_exporter_events_matched`, and the matched rule name is given as a tag of the metrics. All the matched events will be calculated to different tags of the `event_exporter_events_matched` metrics.  like this:
* rule example
```yaml
route:
  routes:
    - match:
        - receiver: "alerts"
          reason: "FailedScheduling"
          name: "FailedScheduling"
    - match:
        - reason: ScalingReplicaSet
          receiver: alerts
          name: "ScalingReplicaSet"
    - match:
        - reason: Kill
          receiver: alerts
```
* metrics example
```
event_exporter_events_matched{route="FailedScheduling"} 2
event_exporter_events_matched{route="ScalingReplicaSet"} 12
event_exporter_events_matched{route="default"} 15
```

`name` property of rule can be defined, and if it is empty, the matched events will be calculated to the metrics with `default` name-tag.
