### PR TITLE
feat: Allow using templates in indexFormat for OpenSearch sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ receivers:
       hosts:
         - http://localhost:9200
       index: kube-events
-      # Ca be used optionally for time based indices, accepts Go time formatting directives
-      indexFormat: "kube-events-{2006-01-02}"
+      # Can be used optionally for time based indices, accepts templates and Go time formatting directives
+      indexFormat: "kube-events-{{ .InvolvedObject.Namespace }}-{2006-01-02}"
       username: # optional
       password: # optional
       # If set to true, it allows updating the same document in ES (might be useful handling count)

--- a/pkg/sinks/opensearch_test.go
+++ b/pkg/sinks/opensearch_test.go
@@ -1,0 +1,63 @@
+package sinks
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/resmoio/kubernetes-event-exporter/pkg/kube"
+	"github.com/stretchr/testify/assert"
+)
+
+func makeTestEvent() *kube.EnhancedEvent {
+	ev := &kube.EnhancedEvent{}
+	ev.Namespace = "default"
+	ev.Type = "Warning"
+	ev.InvolvedObject.Kind = "Pod"
+	ev.InvolvedObject.Name = "nginx-server-123abc-456def"
+	ev.Message = "Successfully pulled image \"nginx:latest\""
+	return ev
+}
+
+func TestOpenSearch_LegacyTime(t *testing.T) {
+	p := "legacy-time-pattern-{2006-01-02}"
+	ev := makeTestEvent()
+	w := time.Now()
+
+	r, err := osFormatIndexName(p, w, ev)
+
+	assert.Nil(t, err)
+	assert.Equal(t, fmt.Sprintf("legacy-time-pattern-%d-%02d-%02d", w.Year(), w.Month(), w.Day()), r)
+}
+
+func TestOpenSearch_JustEventInfo(t *testing.T) {
+	p := "{{ .Namespace }}-{{ .InvolvedObject.Kind }}-static"
+	ev := makeTestEvent()
+	w := time.Now()
+
+	r, err := osFormatIndexName(p, w, ev)
+
+	assert.Nil(t, err)
+	assert.Equal(t, "default-Pod-static", r)
+}
+
+func TestOpenSearch_EventAndTime(t *testing.T) {
+	p := "{{ .Namespace }}-{2006-01-02}-{{ .Type }}"
+	ev := makeTestEvent()
+	w := time.Now()
+
+	r, err := osFormatIndexName(p, w, ev)
+
+	assert.Nil(t, err)
+	assert.Equal(t, fmt.Sprintf("default-%d-%02d-%02d-Warning", w.Year(), w.Month(), w.Day()), r)
+}
+
+func TestOpenSearch_InvalidEvent(t *testing.T) {
+	p := "{{ .NotPresent }}-{2006-01-02}"
+	ev := makeTestEvent()
+	w := time.Now()
+
+	_, err := osFormatIndexName(p, w, ev)
+
+	assert.ErrorContains(t, err, "can't evaluate field NotPresent")
+}


### PR DESCRIPTION
This PR adds the capability to use templates when constructing the `indexFormat` for OpenSearch sinks.

The change is backwards compatible with the existing time formatting directives - this is ensured by the added tests.

Given an example configuration:
```
receivers:
  - name: "by-namespace"
    opensearch:
      hosts:
        - http://localhost:9200
      indexFormat: "kube-events-{{ .InvolvedObject.Namespace }}-{2006-01-02}"
```
An event originating from `kube-system` will end up in a index named `kube-events-kube-system-<go formatted date>`.

Closes #155 