### PR TITLE
Add liveness/readiness probes, resource requests/limits

### DIFF
--- a/deploy/02-deployment.yaml
+++ b/deploy/02-deployment.yaml
@@ -35,6 +35,20 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: [ALL]
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: 2112
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 2112
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              memory: 128Mi
       volumes:
         - name: cfg
           configMap:


### PR DESCRIPTION
Moves it out of the BestEffort QoS class, making it less likely to be killed during high memory pressure, which is exactly the time when the exporter is needed.