### PR TITLE
fix: enhance error logging for channel and sync registries

### DIFF
--- a/pkg/exporter/channel_registry.go
+++ b/pkg/exporter/channel_registry.go
@@ -59,7 +59,7 @@ func (r *ChannelBasedReceiverRegistry) Register(name string, receiver sinks.Sink
 				err := receiver.Send(context.Background(), &ev)
 				if err != nil {
 					r.MetricsStore.SendErrors.Inc()
-					log.Debug().Err(err).Str("sink", name).Str("event", ev.Message).Msg("Cannot send event")
+					log.Warn().Err(err).Str("sink", name).Str("event", ev.Message).Msg("Cannot send event")
 				}
 			case <-exitCh:
 				log.Info().Str("sink", name).Msg("Closing the sink")

--- a/pkg/exporter/sync_registry.go
+++ b/pkg/exporter/sync_registry.go
@@ -16,7 +16,7 @@ type SyncRegistry struct {
 func (s *SyncRegistry) SendEvent(name string, event *kube.EnhancedEvent) {
 	err := s.reg[name].Send(context.Background(), event)
 	if err != nil {
-		log.Debug().Err(err).Str("sink", name).Str("event", string(event.UID)).Msg("Cannot send event")
+		log.Warn().Err(err).Str("sink", name).Str("event", string(event.UID)).Msg("Cannot send event")
 	}
 }
 


### PR DESCRIPTION
Hi @resmoio,

I've submitted a patch that changes the logging level from Debug to Warn for error messages related to event sending failures in both the channel and sync registries.

The motivation behind this change is to improve the visibility of these errors. Given that event sending is a critical function within this application, it's essential to surface these issues more prominently. By logging these errors at the Warn level, it becomes significantly easier to identify and investigate problems when they occur.