### PR TITLE
feat: add bool support for convertTemplate func

### DIFF
--- a/pkg/sinks/tmpl.go
+++ b/pkg/sinks/tmpl.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"text/template"
 
-	"github.com/resmoio/kubernetes-event-exporter/pkg/kube"
 	"github.com/Masterminds/sprig/v3"
+	"github.com/resmoio/kubernetes-event-exporter/pkg/kube"
 )
 
 func GetString(event *kube.EnhancedEvent, text string) (string, error) {
@@ -40,6 +40,8 @@ func convertLayoutTemplate(layout map[string]interface{}, ev *kube.EnhancedEvent
 
 func convertTemplate(value interface{}, ev *kube.EnhancedEvent) (interface{}, error) {
 	switch v := value.(type) {
+	case bool:
+		return v, nil
 	case string:
 		rendered, err := GetString(ev, v)
 		if err != nil {


### PR DESCRIPTION
Added boolean support to the convertTemplate function to handle the following layout:

```yaml
receivers:
- webhook:
    layout:
      attachments:
      - content:
          type: AdaptiveCard
          body:
          - type: Container
            items:
            - type: TextBlock
              text: "{{ .Message }}"
              wrap: true  # bool in here
```