### PR TITLE
Add Basic Auth support for Loki sink

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -122,3 +122,8 @@ receivers:
       deliveryStreamName: "kubernetes-events"
       region: "us-east-1"
       deDot: true
+  - name: "loki"
+    loki:
+      url: "http://localhost:3100/loki/api/v1/push"
+      username: "your-username"
+      password: "your-password"

--- a/pkg/sinks/loki.go
+++ b/pkg/sinks/loki.go
@@ -29,6 +29,8 @@ type LokiConfig struct {
 	TLS          TLS                    `yaml:"tls"`
 	URL          string                 `yaml:"url"`
 	Headers      map[string]string      `yaml:"headers"`
+	Username     string                 `yaml:"username"` // P02cc
+	Password     string                 `yaml:"password"` // P02cc
 }
 
 type Loki struct {
@@ -83,6 +85,10 @@ func (l *Loki) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
 			log.Debug().Msgf("request header: {%s: %s}", k, realValue)
 			req.Header.Add(k, realValue)
 		}
+	}
+
+	if l.cfg.Username != "" && l.cfg.Password != "" { // Pd21d
+		req.SetBasicAuth(l.cfg.Username, l.cfg.Password) // Pd21d
 	}
 
 	client := http.DefaultClient

--- a/pkg/sinks/loki_test.go
+++ b/pkg/sinks/loki_test.go
@@ -1,0 +1,66 @@
+package sinks
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/resmoio/kubernetes-event-exporter/pkg/kube"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoki_SendWithBasicAuth(t *testing.T) {
+	username := "testuser"
+	password := "testpass"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		expectedAuth := "Basic " + basicAuth(username, password)
+		assert.Equal(t, expectedAuth, auth)
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	cfg := &LokiConfig{
+		URL:      ts.URL,
+		Username: username,
+		Password: password,
+	}
+
+	loki, err := NewLoki(cfg)
+	assert.NoError(t, err)
+
+	ev := &kube.EnhancedEvent{}
+	err = loki.Send(context.Background(), ev)
+	assert.NoError(t, err)
+}
+
+func basicAuth(username, password string) string {
+	auth := username + ":" + password
+	return base64.StdEncoding.EncodeToString([]byte(auth))
+}
+
+func TestLoki_SendWithoutBasicAuth(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		assert.Empty(t, auth)
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	cfg := &LokiConfig{
+		URL: ts.URL,
+	}
+
+	loki, err := NewLoki(cfg)
+	assert.NoError(t, err)
+
+	ev := &kube.EnhancedEvent{}
+	err = loki.Send(context.Background(), ev)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/resmoio/kubernetes-event-exporter/pull/218?shareId=c5a5a510-6658-417f-b4f4-3c74de22f605).