### PR TITLE
OpenSearch, ElasticSearch: add option to enable gzip compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ receivers:
         insecureSkipVerify: true|false # optional, if set to true, the tls cert won't be verified
         serverName: # optional, the domain, the certificate was issued for, in case it doesn't match the hostname used for the connection
         caFile: # optional, path to the CA file of the trusted authority the cert was signed with
+      # If set to true, gzip compression is used for requests to OpenSearch. Defaults to false.
+      compressRequestBody: true|false
 ```
 
 ### Slack

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ receivers:
         insecureSkipVerify: true|false # optional, if set to true, the tls cert won't be verified
         serverName: # optional, the domain, the certificate was issued for, in case it doesn't match the hostname used for the connection
         caFile: # optional, path to the CA file of the trusted authority the cert was signed with
+      # If set to true, gzip compression is used for requests to ElasticSearch. Defaults to false.
+      compressRequestBody: true|false
 ```
 ### OpenSearch
 

--- a/pkg/sinks/elasticsearch.go
+++ b/pkg/sinks/elasticsearch.go
@@ -28,12 +28,13 @@ type ElasticsearchConfig struct {
 	// Indexing preferences
 	UseEventID bool `yaml:"useEventID"`
 	// DeDot all labels and annotations in the event. For both the event and the involvedObject
-	DeDot       bool                   `yaml:"deDot"`
-	Index       string                 `yaml:"index"`
-	IndexFormat string                 `yaml:"indexFormat"`
-	Type        string                 `yaml:"type"`
-	TLS         TLS                    `yaml:"tls"`
-	Layout      map[string]interface{} `yaml:"layout"`
+	DeDot               bool                   `yaml:"deDot"`
+	Index               string                 `yaml:"index"`
+	IndexFormat         string                 `yaml:"indexFormat"`
+	Type                string                 `yaml:"type"`
+	TLS                 TLS                    `yaml:"tls"`
+	Layout              map[string]interface{} `yaml:"layout"`
+	CompressRequestBody bool                   `yaml:"compressRequestBody"`
 }
 
 func NewElasticsearch(cfg *ElasticsearchConfig) (*Elasticsearch, error) {
@@ -60,6 +61,7 @@ func NewElasticsearch(cfg *ElasticsearchConfig) (*Elasticsearch, error) {
 		Transport: &http.Transport{
 			TLSClientConfig: tlsClientConfig,
 		},
+		CompressRequestBody: cfg.CompressRequestBody,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/sinks/opensearch.go
+++ b/pkg/sinks/opensearch.go
@@ -25,12 +25,13 @@ type OpenSearchConfig struct {
 	// Indexing preferences
 	UseEventID bool `yaml:"useEventID"`
 	// DeDot all labels and annotations in the event. For both the event and the involvedObject
-	DeDot       bool                   `yaml:"deDot"`
-	Index       string                 `yaml:"index"`
-	IndexFormat string                 `yaml:"indexFormat"`
-	Type        string                 `yaml:"type"`
-	TLS         TLS                    `yaml:"tls"`
-	Layout      map[string]interface{} `yaml:"layout"`
+	DeDot               bool                   `yaml:"deDot"`
+	Index               string                 `yaml:"index"`
+	IndexFormat         string                 `yaml:"indexFormat"`
+	Type                string                 `yaml:"type"`
+	TLS                 TLS                    `yaml:"tls"`
+	Layout              map[string]interface{} `yaml:"layout"`
+	CompressRequestBody bool                   `yaml:"compressRequestBody"`
 }
 
 func NewOpenSearch(cfg *OpenSearchConfig) (*OpenSearch, error) {
@@ -47,6 +48,7 @@ func NewOpenSearch(cfg *OpenSearchConfig) (*OpenSearch, error) {
 		Transport: &http.Transport{
 			TLSClientConfig: tlsClientConfig,
 		},
+		CompressRequestBody: cfg.CompressRequestBody,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
gzip compression can significantly reduce the bandwith used by traffic to opensearch/elasticsearch. This PR adds a configuration option to the opensearch/elasticsearch config section to enable the compression.