### PR TITLE
Support AWS signing and improve error logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	cloud.google.com/go/pubsub v1.28.0
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/Shopify/sarama v1.37.2
-	github.com/aws/aws-sdk-go v1.44.162
+	github.com/aws/aws-sdk-go v1.50.36
 	github.com/elastic/go-elasticsearch/v7 v7.17.7
 	github.com/goccy/go-yaml v1.11.0
 	github.com/hashicorp/golang-lru v0.5.3
@@ -18,7 +18,7 @@ require (
 	github.com/prometheus/exporter-toolkit v0.10.0
 	github.com/rs/zerolog v1.28.0
 	github.com/slack-go/slack v0.12.0
-	github.com/stretchr/testify v1.8.1
+	github.com/stretchr/testify v1.9.0
 	google.golang.org/api v0.107.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	k8s.io/api v0.26.7
@@ -27,6 +27,7 @@ require (
 )
 
 require (
+	github.com/opensearch-project/opensearch-go/v3 v3.1.0 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/aws/aws-sdk-go v1.42.27/go.mod h1:OGr6lGMAKGlG9CVrYnWYDKIyb829c6EVBRjxqjmPepc=
 github.com/aws/aws-sdk-go v1.44.162 h1:hKAd+X+/BLxVMzH+4zKxbQcQQGrk2UhFX0OTu1Mhon8=
 github.com/aws/aws-sdk-go v1.44.162/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
+github.com/aws/aws-sdk-go v1.50.36 h1:PjWXHwZPuTLMR1NIb8nEjLucZBMzmf84TLoLbD8BZqk=
+github.com/aws/aws-sdk-go v1.50.36/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
@@ -244,6 +246,8 @@ github.com/onsi/ginkgo/v2 v2.4.0 h1:+Ig9nvqgS5OBSACXNk15PLdp0U9XPYROt9CFzVdFGIs=
 github.com/onsi/gomega v1.23.0 h1:/oxKu9c2HVap+F3PfKort2Hw5DEU+HGlW8n+tguWsys=
 github.com/opensearch-project/opensearch-go v1.1.0 h1:eG5sh3843bbU1itPRjA9QXbxcg8LaZ+DjEzQH9aLN3M=
 github.com/opensearch-project/opensearch-go v1.1.0/go.mod h1:+6/XHCuTH+fwsMJikZEWsucZ4eZMma3zNSeLrTtVGbo=
+github.com/opensearch-project/opensearch-go/v3 v3.1.0 h1:7EghS/+dCYD6PrsXjfIf3fvMOObkPtrDJVbovlNl3sY=
+github.com/opensearch-project/opensearch-go/v3 v3.1.0/go.mod h1:9UWs3sbIESBpsGlfhTmj5PXm3tXvgxRan4D+W9d700Q=
 github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.14 h1:ni+M5q9QIZQq5xQiYzbttDZpPQogPWx8MdHpvZtWcTE=
 github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.14/go.mod h1:4OjcxgwdXzezqytxN534MooNmrxRD50geWZxTD7845s=
 github.com/pierrec/lz4/v4 v4.1.17 h1:kV4Ip+/hUBC+8T6+2EgburRtkE9ef4nbY3f4dFhGjMc=
@@ -298,6 +302,8 @@ github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.1.2 h1:FHX5I5B4i4hKRVRBCFRxq1iQRej7WO3hhBuJf+UUySY=

--- a/pkg/exporter/channel_registry.go
+++ b/pkg/exporter/channel_registry.go
@@ -59,7 +59,7 @@ func (r *ChannelBasedReceiverRegistry) Register(name string, receiver sinks.Sink
 				err := receiver.Send(context.Background(), &ev)
 				if err != nil {
 					r.MetricsStore.SendErrors.Inc()
-					log.Debug().Err(err).Str("sink", name).Str("event", ev.Message).Msg("Cannot send event")
+					log.Error().Err(err).Str("sink", name).Str("event", ev.Message).Msg("Cannot send event")
 				}
 			case <-exitCh:
 				log.Info().Str("sink", name).Msg("Closing the sink")

--- a/pkg/sinks/opensearch.go
+++ b/pkg/sinks/opensearch.go
@@ -5,16 +5,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"regexp"
 	"strings"
 	"time"
 
-	opensearch "github.com/opensearch-project/opensearch-go"
-	opensearchapi "github.com/opensearch-project/opensearch-go/opensearchapi"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/opensearch-project/opensearch-go/v3"
+	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
+	requestsigner "github.com/opensearch-project/opensearch-go/v3/signer/aws"
 	"github.com/resmoio/kubernetes-event-exporter/pkg/kube"
-	"github.com/rs/zerolog/log"
 )
 
 type OpenSearchConfig struct {
@@ -31,23 +31,34 @@ type OpenSearchConfig struct {
 	Type        string                 `yaml:"type"`
 	TLS         TLS                    `yaml:"tls"`
 	Layout      map[string]interface{} `yaml:"layout"`
+	AWSService  string                 `yaml:"awsService"` // Leave blank to not do AWS SigV4 signing. Otherwise, set to "es" for Amazon OpenSearch or "aoss" for Amazon OpenSearch Serverless.
 }
 
 func NewOpenSearch(cfg *OpenSearchConfig) (*OpenSearch, error) {
-
 	tlsClientConfig, err := setupTLS(&cfg.TLS)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup TLS: %w", err)
 	}
-
-	client, err := opensearch.NewClient(opensearch.Config{
+	openSearchConfig := opensearch.Config{
 		Addresses: cfg.Hosts,
 		Username:  cfg.Username,
 		Password:  cfg.Password,
 		Transport: &http.Transport{
 			TLSClientConfig: tlsClientConfig,
 		},
-	})
+	}
+	if cfg.AWSService != "" {
+		// Enable AWS SigV4 signing for OpenSearch requests
+		signer, err := requestsigner.NewSignerWithService(
+			session.Options{SharedConfigState: session.SharedConfigEnable},
+			cfg.AWSService,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize AWS signer: %w", err)
+		}
+		openSearchConfig.Signer = signer
+	}
+	client, err := opensearchapi.NewClient(opensearchapi.Config{Client: openSearchConfig})
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +70,7 @@ func NewOpenSearch(cfg *OpenSearchConfig) (*OpenSearch, error) {
 }
 
 type OpenSearch struct {
-	client *opensearch.Client
+	client *opensearchapi.Client
 	cfg    *OpenSearchConfig
 }
 
@@ -112,34 +123,17 @@ func (e *OpenSearch) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
 		index = e.cfg.Index
 	}
 
-	req := opensearchapi.IndexRequest{
+	req := opensearchapi.IndexReq{
 		Body:  bytes.NewBuffer(toSend),
 		Index: index,
-	}
-
-	// This should not be used for clusters with ES8.0+.
-	if len(e.cfg.Type) > 0 {
-		req.DocumentType = e.cfg.Type
 	}
 
 	if e.cfg.UseEventID {
 		req.DocumentID = string(ev.UID)
 	}
 
-	resp, err := req.Do(ctx, e.client)
-	if err != nil {
-		return err
-	}
-
-	defer resp.Body.Close()
-	if resp.StatusCode > 399 {
-		rb, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return err
-		}
-		log.Error().Msgf("Indexing failed: %s", string(rb))
-	}
-	return nil
+	_, err := e.client.Index(ctx, req)
+	return err
 }
 
 func (e *OpenSearch) Close() {


### PR DESCRIPTION
To make kubernetes-event-exporter easier to use for users shipping to Amazon-hosted OpenSearch Service, support AWS Signature V4 signing in the OpenSearch sink. If the `awsService` config property is not blank, use the opensearch-go library's recommended AWS signer setup.
- That requires updating to opensearch-go v3, which has the breaking change of no longer supporting mapping types (i.e. the top-level `_type` field).
- opensearch-go v3 simplifies error handling as it automatically checks for response errors.

Bump up the log level for sink errors from "debug" to "error" so that those errors aren't buried in noise.

Clean up unused imports.